### PR TITLE
Fixing an issue where the Token would lock under certain conditions

### DIFF
--- a/scripts/ClientKeybindings.js
+++ b/scripts/ClientKeybindings.js
@@ -26,6 +26,7 @@ function _onMeasuredRulerMovement(wrapped, context) {
 
   // For each controlled token, end the drag.
   canvas.tokens.clearPreviewContainer();
+  ruler.token.document.locked = false;
   ruler.moveToken().then(_response => ruler._endMeasurement());
   return true;
 }


### PR DESCRIPTION
My attempt to fix the issue detailed here https://github.com/caewok/fvtt-elevation-ruler/issues/145

The token.document.locked was set when a player did a CTRL+Drag on a token with waypoints. Setup ClientKeyBindings to unlock the token before trying to move it.