### PR TITLE
Combine Prior with Total

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Elevation Ruler defines certain keybindings:
 - Use Token Ruler: Display the ruler when dragging tokens.
 - Use Token Speed Highlighting: Highlight grid squares under the ruler based on the token's speed. See API, below, for how to modify colors and speed categories.
 - Track Combat Move: When displaying the speed highlighting during combat, count any movement already made by the token this combat round.
+- Combine Prior Movement with Total Movement: When Track Combat Move is enabled, combine the token's prior movement in the round with the total movement. Otherwise, place the prior movement on a separate line.
 - Round Distance to Multiple: Round the measurement display by this multiple. For example, "10" will round 111.23 to 110.
 - Token as Terrain Multiplier: How much does a token penalize movement through that token?
 - Terrain Grid Measurement: When measuring movement through terrain on a gridded map, how should the terrain be accounted for?

--- a/languages/en.json
+++ b/languages/en.json
@@ -58,6 +58,9 @@
     "elevationruler.settings.token-ruler-combat-history.name": "Track Combat Move",
     "elevationruler.settings.token-ruler-combat-history.hint": "For token speed highlighting, sum all the token moves within the round when displaying the highlight.",
 
+    "elevationruler.settings.combine-prior-with-total.name": "Combine Prior Movement with Total Movement",
+    "elevationruler.settings.combine-prior-with-total.hint": "When Track Combat Move is enabled, combine the token's prior movement in the round with the total movement. Otherwise, place the prior movement on a separate line.",
+
     "elevationruler.settings.token-speed-property.name": "Token Walk Property",
     "elevationruler.settings.token-speed-property.hint": "For token speed highlighting, this is the actor property representing token walking speed.",
 

--- a/scripts/Ruler.js
+++ b/scripts/Ruler.js
@@ -34,6 +34,7 @@ import {
 import { movementTypeForTokenAt } from "./token_hud.js";
 import {
   distanceLabel,
+  getPriorDistance,
   segmentElevationLabel,
   segmentTerrainLabel,
   segmentCombatLabel,
@@ -431,6 +432,9 @@ function _getSegmentLabel(wrapped, segment, totalDistance) {
   // Force distance to be between waypoints instead of (possibly pathfinding) segments.
   const origSegmentDistance = segment.distance;
   segment.distance = distanceLabel(origSegmentDistance);
+  const priorDistance = getPriorDistance(this.token);
+  const combinePriorWithTotal = Settings.get(Settings.KEYS.SPEED_HIGHLIGHTING.COMBINE_PRIOR_WITH_TOTAL)
+  this.totalDistance = distanceLabel(totalDistance) + ((combinePriorWithTotal && segment.first) ? priorDistance : 0);
   const origLabel = wrapped(segment, distanceLabel(totalDistance));
   segment.distance = origSegmentDistance;
 
@@ -445,7 +449,7 @@ function _getSegmentLabel(wrapped, segment, totalDistance) {
   const terrainLabel = segmentTerrainLabel(segment);
 
   // Label when in combat and there are past moves.
-  const combatLabel = segmentCombatLabel(this.token);
+  const combatLabel = (combinePriorWithTotal) ? "" : segmentCombatLabel(this.token, priorDistance);
 
   // Put it all together.
   let label = `${origLabel}`;

--- a/scripts/Token.js
+++ b/scripts/Token.js
@@ -58,8 +58,10 @@ function preUpdateToken(document, changes, _options, _userId) {
     // Store the combat move distance and the last round for which the combat move occurred.
     // Map to each unique combat.
     const combatData = {...token._combatMoveData};
-    if ( combatData.lastRound < game.combat.round ) combatData.lastMoveDistance = lastMoveDistance;
-    else combatData.lastMoveDistance += lastMoveDistance;
+    if ( _options.firstRulerSegment ) {
+      if (combatData.lastRound < game.combat.round ) combatData.lastMoveDistance = lastMoveDistance;
+      else combatData.lastMoveDistance += lastMoveDistance;
+    }
     combatData.numDiagonal = numDiagonal;
     combatData.lastRound = game.combat.round;
     combatMoveData = { [game.combat.id]: combatData };

--- a/scripts/segment_labels_highlighting.js
+++ b/scripts/segment_labels_highlighting.js
@@ -164,11 +164,15 @@ export function segmentTerrainLabel(s) {
  * @param {object} s    Ruler segment
  * @returns {string} The label or "" if none.
  */
-export function segmentCombatLabel(token) {
-  if ( game.combat?.started && Settings.get(Settings.KEYS.SPEED_HIGHLIGHTING.COMBAT_HISTORY) ) {
-    const pastMoveDistance = token?.lastMoveDistance;
-    const units = (canvas.scene.grid.units) ? ` ${canvas.scene.grid.units}` : "";
-    if ( pastMoveDistance ) return `\nPrior: ${distanceLabel(pastMoveDistance)}${units}`;
-  }
+export function segmentCombatLabel(token, priorDistance) {
+  const units = (canvas.scene.grid.units) ? ` ${canvas.scene.grid.units}` : "";
+  if ( priorDistance ) return `\nPrior: ${priorDistance}${units}`;
   return "";
+}
+
+export function getPriorDistance(token) {
+  if ( game.combat?.started && Settings.get(Settings.KEYS.SPEED_HIGHLIGHTING.COMBAT_HISTORY) ) {
+    return distanceLabel(token?.lastMoveDistance) || 0;
+  }
+  return 0;
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -54,6 +54,7 @@ const SETTINGS = {
     CHOICE: "speed-highlighting-choice", // New multiple-choice for enabling speed highlighting.
     NO_HOSTILES: "speed-highlighting-no-hostiles",
     COMBAT_HISTORY: "token-ruler-combat-history",
+    COMBINE_PRIOR_WITH_TOTAL: "combine-prior-with-total",
     CHOICES: {
       NEVER: "speed-highlighting-choice-never",
       COMBAT: "speed-highlighting-choice-combat",
@@ -233,6 +234,16 @@ export class Settings extends ModuleSettingsAbstract {
     register(KEYS.SPEED_HIGHLIGHTING.COMBAT_HISTORY, {
       name: localize(`${KEYS.SPEED_HIGHLIGHTING.COMBAT_HISTORY}.name`),
       hint: localize(`${KEYS.SPEED_HIGHLIGHTING.COMBAT_HISTORY}.hint`),
+      scope: "user",
+      config: true,
+      default: false,
+      type: Boolean,
+      requiresReload: false
+    });
+
+    register(KEYS.SPEED_HIGHLIGHTING.COMBINE_PRIOR_WITH_TOTAL, {
+      name: localize(`${KEYS.SPEED_HIGHLIGHTING.COMBINE_PRIOR_WITH_TOTAL}.name`),
+      hint: localize(`${KEYS.SPEED_HIGHLIGHTING.COMBINE_PRIOR_WITH_TOTAL}.hint`),
       scope: "user",
       config: true,
       default: false,


### PR DESCRIPTION
![elevation-ruler-combine-prior-with-total](https://github.com/user-attachments/assets/8380d12b-5b82-4364-874b-4cd71e10d741)

- Add a setting to combine the prior movement with the total movement instead of showing it on a separate line.
- Apply rounding on total movement (whether prior movement is combined or not).
- Fix error with `combatData.lastMoveDistance` doubling up for every segment.