### PR TITLE
Removed Wall Height Vaulting flag

### DIFF
--- a/scripts/pathfinding/WallTracer.js
+++ b/scripts/pathfinding/WallTracer.js
@@ -383,7 +383,7 @@ export class WallTracerEdge extends GraphEdge {
 
     // If Wall Height vaulting is enabled, walls less than token vision height do not block.
     const wh = OTHER_MODULES.WALL_HEIGHT;
-    if ( wh.ACTIVE && game.settings.get(wh.KEY, wh.FLAGS.VAULTING) && moveToken.visionZ >= wall.topZ ) return false;
+    if ( wh.ACTIVE && moveToken.visionZ >= wall.topZ ) return false;
     return true;
   }
 


### PR DESCRIPTION
As of [v6.1.0 of Wall Height](https://github.com/theripper93/wall-height/releases/tag/6.1.0) the legacy vaulting flag was removed, and the module now behaves as if it is on. This broke pathfinding, so the reference to this flag has been removed.