### PR TITLE
updated system attributes for SWADE 4.2.0+

### DIFF
--- a/scripts/system_attributes.js
+++ b/scripts/system_attributes.js
@@ -104,7 +104,7 @@ export function defaultWalkAttribute() {
     case "pf1":
     case "D35E":            return "actor.system.attributes.speed.land.total";
     case "shadowrun5e":     return "actor.system.movement.walk.value";
-    case "swade":           return "actor.system.stats.speed.adjusted";
+    case "swade":           return "actor.system.pace.ground";
     case "ds4":             return "actor.system.combatValues.movement.total";
     case "splittermond":    return "actor.derivedValues.speed.value";
     case "wfrp4e":          return "actor.system.details.move.walk";
@@ -131,6 +131,7 @@ export function defaultFlyAttribute() {
     case "dnd5e":           return "actor.system.attributes.movement.fly";
     case "pf1":
     case "D35E":            return "actor.system.attributes.speed.fly.total";
+    case "swade":           return "actor.system.pace.fly";
     case "twodsix":         return "actor.system.movement.fly";
     case "worldofdarkness": return "actor.system.movement.fly";
     case "gurps":           return "actor.system.currentflight";
@@ -151,6 +152,7 @@ export function defaultBurrowAttribute() {
     case "dnd5e":         return "actor.system.attributes.movement.burrow";
     case "pf1":
     case "D35E":          return "actor.system.attributes.speed.burrow.total";
+    case "swade":         return "actor.system.pace.burrow";
     case "twodsix":       return "actor.system.movement.burrow";
     default:              return "";
   }


### PR DESCRIPTION
SWADE 4.2.0 moved pace, now `actor.system.pace` is an object with (for instance):
```js
{
  base: "ground",
  burrow: null,
  fly: 3,
  ground: 6,
  running: {
    die: 6,
    mod: 0
  },
  swim: null
}
```
Modified `system_attributes.js` accordingly.